### PR TITLE
Build macos arm64 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   # Only support 64-bit CPython >= 3.7
-  # VTK does not currently build python 3.8 arm64 wheels, so skip it too
+  # Only support macOS ARM 64-bit CPython >= 3.9 (older VTK wheels and SDKs not available)
   CIBW_SKIP: "cp27-* cp35-* cp36-* cp37-* pp* *-manylinux_i686 *-musllinux_* *-win32 cp38-macosx_arm64"
 
   # Need to match the version used by VTK
@@ -27,11 +27,8 @@ env:
   # In the Linux docker container, install the wheel SDKs to this location
   CIBW_ENVIRONMENT_LINUX: VTK_WHEEL_SDK_INSTALL_PATH=/vtk-wheel-sdk
 
-  # NOTE: cross-compilation is not currently working for us for arm64.
-  # We are going to turn it off and build them manually until GitHub Actions
-  # makes arm64 runners available.
   # Build both x86_64 and arm64 (through cross-compilation) wheels on Mac
-  # CIBW_ARCHS_MACOS: x86_64 arm64
+  CIBW_ARCHS_MACOS: x86_64 arm64
 
   # VTK already fixes the rpaths, so we can skip this step for MacOS
   CIBW_REPAIR_WHEEL_COMMAND_MACOS:

--- a/BuildVTKCompileTools.cmake
+++ b/BuildVTKCompileTools.cmake
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 3.15)
+
+function(display_status msg)
+  message(STATUS "")
+  message(STATUS "${msg}")
+  message(STATUS "")
+endfunction()
+
+#
+# Download and build VTKCompileTools
+#
+
+if(NOT DEFINED VTKCompileTools_DIR)
+  message(FATAL_ERROR "Variable VTKCompileTools_DIR is not defined")
+endif()
+
+if(NOT DEFINED VTKCompileTools_POPULATE_DIR)
+  message(FATAL_ERROR "Variable VTKCompileTools_POPULATE_DIR is not defined")
+endif()
+
+set(proj "vtk-compile-tools")
+
+display_status("${proj} - VTKCompileTools_DIR:${VTKCompileTools_DIR}")
+
+if(NOT DEFINED VTK_SOURCE_DIR)
+
+  set(VTK_SOURCE_DIR ${VTKCompileTools_POPULATE_DIR}/VTK)
+
+  if(NOT DEFINED VTK_WHEEL_SDK_VERSION)
+    message(FATAL_ERROR "Variable VTK_WHEEL_SDK_VERSION is not defined")
+  endif()
+  display_status("${proj} - VTK_WHEEL_SDK_VERSION:${VTK_WHEEL_SDK_VERSION}")
+
+  include(FetchContent)
+  FetchContent_Populate(${proj}
+    SOURCE_DIR ${VTK_SOURCE_DIR}
+    BINARY_DIR ${VTKCompileTools_POPULATE_DIR}/${proj}-build
+    SUBBUILD_DIR ${VTKCompileTools_POPULATE_DIR}/${proj}-subbuild
+    GIT_REPOSITORY "https://github.com/Kitware/VTK.git"
+    GIT_TAG v${VTK_WHEEL_SDK_VERSION}
+    GIT_SHALLOW 1
+    GIT_PROGRESS 1
+    )
+else()
+  display_status("${proj} - Skipping VTK download (VTK_SOURCE_DIR is defined)")
+endif()
+
+display_status("${proj} - VTK_SOURCE_DIR:${VTK_SOURCE_DIR}")
+
+display_status("${proj} - Configuring ${VTKCompileTools_DIR}")
+execute_process(
+  COMMAND
+    ${CMAKE_COMMAND}
+      -DVTK_BUILD_COMPILE_TOOLS_ONLY:BOOL=ON
+      -DCMAKE_BUILD_TYPE:STRING=Release
+      -DVTK_BUILD_ALL_MODULES:BOOL=OFF
+      -DBUILD_SHARED_LIBS:BOOL=ON
+      -DVTK_BUILD_EXAMPLES:BOOL=OFF
+      -DVTK_BUILD_TESTING:BOOL=OFF
+      -DVTK_ENABLE_LOGGING:BOOL=OFF
+      -S ${VTK_SOURCE_DIR}
+      -B ${VTKCompileTools_DIR}
+  )
+
+include(ProcessorCount)
+ProcessorCount(nproc)
+
+display_status("${proj} - Building ${VTKCompileTools_DIR} [--parallel ${nproc}]")
+execute_process(
+  COMMAND
+    ${CMAKE_COMMAND}
+      --build ${VTKCompileTools_DIR}
+      --config Release
+      --parallel ${nproc}
+  )
+
+#
+# Build VTKCompileToolsTest
+#
+
+display_status("${proj} - Testing ${VTKCompileTools_DIR}")
+
+set(test_proj_src_dir ${CMAKE_CURRENT_LIST_DIR}/Testing/VTKCompileTools)
+set(test_proj_bld_dir ${VTKCompileTools_POPULATE_DIR}/VTKCompileToolsTest-build)
+
+execute_process(
+  COMMAND
+    ${CMAKE_COMMAND}
+      -DVTKCompileTools_DIR:PATH=${VTKCompileTools_DIR}
+      -S ${test_proj_src_dir}
+      -B ${test_proj_bld_dir}
+  )

--- a/SuperBuild/External_U3D.cmake
+++ b/SuperBuild/External_U3D.cmake
@@ -32,6 +32,7 @@ if(NOT DEFINED ${proj}_INCLUDE_DIR OR NOT DEFINED ${proj}_IDTF_LIBRARY)
   set(_install_libdir "${CMAKE_INSTALL_LIBDIR}/vtkmodules")
 
   ExternalProject_add(U3D
+    ${${proj}_EP_ARGS}
     GIT_REPOSITORY https://github.com/ClinicalGraphics/u3d.git
     GIT_TAG a2dc4bf9ead5400939f698d5834b7c5d43dbf42a
     SOURCE_DIR ${EP_SOURCE_DIR}

--- a/Testing/VTKCompileTools/CMakeLists.txt
+++ b/Testing/VTKCompileTools/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.12...3.16 FATAL_ERROR)
+
+project(VTKCompileToolsTest)
+
+find_package(VTKCompileTools REQUIRED)
+
+function(display_status msg)
+  message(STATUS "")
+  message(STATUS "${msg}")
+  message(STATUS "")
+endfunction()
+
+function(check_compiletools_exectuable target_name)
+  display_status("Setting ${target_name}_EXECUTABLE")
+  get_target_property(${target_name}_EXECUTABLE VTKCompileTools::${target_name} IMPORTED_LOCATION_RELEASE)
+  if(NOT EXISTS ${${target_name}_EXECUTABLE})
+    message(FATAL_ERROR "${target_name}_EXECUTABLE set to an nonexistent path: ${${target_name}_EXECUTABLE}")
+  endif()
+
+  display_status("Running ${${target_name}_EXECUTABLE}")
+  execute_process(
+    COMMAND ${${target_name}_EXECUTABLE} --help
+    RESULT_VARIABLE result
+    )
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Failed to run ${${target_name}_EXECUTABLE}")
+  endif()
+endfunction()
+
+check_compiletools_exectuable("WrapHierarchy")
+check_compiletools_exectuable("WrapPython")


### PR DESCRIPTION
Closes #17 

To provide some context, this commit reverts the following:

> Turn off arm64 builds in cibuildwheel
> 
> Because GitHub Actions does not yet have arm64 runners available,
> cross-compiling is the only option for making arm64 wheels.
> 
> We are running into several issues with cross-compiling our module,
> including the fact that, apparently, part of the compilation process
> runs at least one executable (vtkWrapHierarchy-9.2) in the VTK SDK
> (which, if we are cross-compiling, will not work since the architecture
> does not match). We also seem to be getting some linking errors, which
> may or may not be important.

_Source: https://github.com/Kitware/LookingGlassVTKModule/commit/3a6888ac395e88004bd1203b3476d2c70e20bae3 from Sept 2022_

Associated GitHub issues related to official support that would avoid relying on cross-compilation:
* https://github.com/github/roadmap/issues/528
* https://github.com/actions/runner-images/issues/2187