### PR TITLE
COMP: Reference VTKExternalModule from upstream instead of a fork

### DIFF
--- a/FetchVTKExternalModule.cmake
+++ b/FetchVTKExternalModule.cmake
@@ -10,8 +10,8 @@ endif()
 
 FetchContent_Populate(${proj}
   SOURCE_DIR     ${EP_SOURCE_DIR}
-  GIT_REPOSITORY https://github.com/jcfr/VTKExternalModule.git
-  GIT_TAG        d6445b187e1b07e7e902810920b954f9cc2cf727
+  GIT_REPOSITORY https://github.com/KitwareMedical/VTKExternalModule.git
+  GIT_TAG        c1906cf121e34b6391a91c2fffc448eca402a6cc
   QUIET
   )
 


### PR DESCRIPTION
This commit does not introduce any functional changes. It is a follow-up of a87228d (ENH: Update VTKExternalModule to build U3D dependency) ensuring the sources a checked out from the upstream project instead of a fork.