### PR TITLE
Update workflow to publish using openid connect

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,6 +12,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Only support 64-bit CPython >= 3.7
   # VTK does not currently build python 3.8 arm64 wheels, so skip it too

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -105,6 +105,9 @@ jobs:
     needs: build_wheels
     name: Upload wheels to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     # upload to PyPI on every tag push
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
     steps:
@@ -114,6 +117,3 @@ jobs:
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d # v1.8.5
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
* ci: cancel in-progress on repeated pushes
* ci: Publish on PyPI using a trusted publisher