### PR TITLE
ENH: Update VTKExternalModule adding support for cross-compilation

### DIFF
--- a/FetchVTKExternalModule.cmake
+++ b/FetchVTKExternalModule.cmake
@@ -11,7 +11,7 @@ endif()
 FetchContent_Populate(${proj}
   SOURCE_DIR     ${EP_SOURCE_DIR}
   GIT_REPOSITORY https://github.com/KitwareMedical/VTKExternalModule.git
-  GIT_TAG        c1906cf121e34b6391a91c2fffc448eca402a6cc
+  GIT_TAG        37ade3c2605fc32a7c3a639fd77073a41e7ad7a8
   QUIET
   )
 


### PR DESCRIPTION
List of changes:

```
$ git shortlog c1906cf12..37ade3c26 --no-merges
Jean-Christophe Fillion-Robin (3):
      Remove redundant BUILD_TESTING option
      COMP: Support configuring install directories
      Add support for finding VTKCompileTools and passing cross-compilation variables
```